### PR TITLE
Adding failing test case for PaginationTest

### DIFF
--- a/tests/Doctrine/Tests/Models/Pagination/Company.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Company.php
@@ -24,6 +24,11 @@ class Company
     public $name;
 
     /**
+     * @Column(type="string", name="jurisdiction_code", nullable=true)
+     */
+    public $jurisdiction;
+
+    /**
      * @OneToOne(targetEntity="Logo", mappedBy="company", cascade={"persist"}, orphanRemoval=true)
      */
     public $logo;

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -602,6 +602,20 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         count($paginator);
     }
 
+    /**
+     * Test using a paginator when the entity attribute name and corresponding column name are not the same.
+     */
+    public function testPaginationWithColumnAttributeNameDifference()
+    {
+        $dql = 'SELECT c FROM Doctrine\Tests\Models\Pagination\Company c ORDER BY c.id';
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query);
+        $paginator->getIterator();
+
+        $this->assertCount(9, $paginator->getIterator());
+    }
+
     public function testCloneQuery()
     {
         $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u';


### PR DESCRIPTION
The failure comes into play when an entity has an attribute named differently from its corresponding column name.
